### PR TITLE
getBalances(): return the state of addresses

### DIFF
--- a/lib/sync.js
+++ b/lib/sync.js
@@ -28,7 +28,7 @@ function sync (iota, transactions, inputs, addresses) {
             transactions[j].inputs.forEach(input => {
               const addressIndex = addresses.findIndex(address => address.address === input.address)
               if (addressIndex !== -1 && 'spending' in addresses[addressIndex]) {
-                addresses[addressIndex].spending -= input.value
+                addresses[addressIndex].spending -= input.balance
               }
             })
           }
@@ -51,13 +51,13 @@ function getPendingTransactions (transactions) {
 }
 
 function updateBalances (iota, addresses) {
-  return new Promise((resolve, reject) => iota.api.getBalances(addresses.map(obj => obj.address), 100, (err, balances) => err ? reject(err) : resolve(balances)))
+  const getBalances = pify(iota.api.getBalances.bind(iota.api))
+  return getBalances(addresses.map(obj => obj.address), 100)
     .then(balances => {
-      addresses = addresses.map((address, i) => {
-        address.value = balances[i]
+      return addresses.map((address, i) => {
+        address.balance = balances[i]
         return address
       })
-      return balances
     })
 }
 

--- a/lib/sync.test.js
+++ b/lib/sync.test.js
@@ -1,5 +1,5 @@
 import test from 'ava'
-import { sync, getConfirmedTransactions, getPendingTransactions } from './sync'
+import { sync, getConfirmedTransactions, getPendingTransactions, updateBalances } from './sync'
 
 test('sync() updates pendingTransfers in inputs', async (t) => {
   const iota = {
@@ -86,10 +86,10 @@ test('sync() updates sending in swept addresses', async (t) => {
       inputs: [
         {
           address: 'AA9999999999999999999999999999999999999999999999999999999999999999999999999999999',
-          value: 1
+          balance: 1
         }, {
           address: 'AB9999999999999999999999999999999999999999999999999999999999999999999999999999999',
-          value: 2
+          balance: 2
         }
       ]
     }
@@ -185,6 +185,48 @@ test('getPendingTransactions() works', t => {
   t.deepEqual(pendingTxs, [
     {
       id: 'def'
+    }
+  ])
+})
+
+test('updateBalances() works', async t => {
+  const iota = {
+    api: {
+      getBalances: (addresses, threshold, cb) => {
+        cb(null, [0, 9, 2, 27])
+      }
+    }
+  }
+  const addresses = [
+    {
+      address: 'A99999999999999999999999999999999999999999999999999999999999999999999999999999999',
+      balance: 7
+    }, {
+      address: 'B99999999999999999999999999999999999999999999999999999999999999999999999999999999',
+      balance: 0
+    }, {
+      address: 'C99999999999999999999999999999999999999999999999999999999999999999999999999999999',
+      balance: 2
+    }, {
+      address: 'D99999999999999999999999999999999999999999999999999999999999999999999999999999999',
+      balance: 10
+    }
+  ]
+  const updatedAddresses = await updateBalances(iota, addresses)
+
+  t.deepEqual(updatedAddresses, [
+    {
+      address: 'A99999999999999999999999999999999999999999999999999999999999999999999999999999999',
+      balance: 0
+    }, {
+      address: 'B99999999999999999999999999999999999999999999999999999999999999999999999999999999',
+      balance: 9
+    }, {
+      address: 'C99999999999999999999999999999999999999999999999999999999999999999999999999999999',
+      balance: 2
+    }, {
+      address: 'D99999999999999999999999999999999999999999999999999999999999999999999999999999999',
+      balance: 27
     }
   ])
 })


### PR DESCRIPTION
- Return the state of addresses with updated balance instead of mutating
- Rename `address.value` -> `address.balance`
- Add test

Solves #16 